### PR TITLE
use latest canvas 1.6.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "resize-logic": "0.0.0",
     "through2": "~0.4.0",
-    "canvas": "~2.4.1",
+    "canvas": "~2.5.0",
     "bl": "~0.7.0"
   },
   "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "resize-logic": "0.0.0",
     "through2": "~0.4.0",
-    "canvas": "~1.6.10",
+    "canvas": "~2.4.1",
     "bl": "~0.7.0"
   },
   "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "resize-logic": "0.0.0",
     "through2": "~0.4.0",
-    "canvas": "~1.1.3",
+    "canvas": "~1.6.10",
     "bl": "~0.7.0"
   },
   "author": "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",


### PR DESCRIPTION
I'm using node v8.9.4.
Older canvas was not precompiled for this version.
And older version won't compile with node v8.9.4.
Can you integrate latest node-canvas and push a release?
I tried it already, it seems to work without problem.